### PR TITLE
Improvements for Python 3

### DIFF
--- a/django_versioned_static_url/templatetags/versioned_static.py
+++ b/django_versioned_static_url/templatetags/versioned_static.py
@@ -20,25 +20,26 @@ def versioned_static(file_path):
     """
 
     full_path = find(file_path)
-    url = static(file_path)
 
+    if not full_path:
+        msg = 'Could not find static file: {0}'.format(file_path)
+        raise Exception(msg)
+
+    url = static(file_path)
     versioned_url_path = url
 
-    if isinstance(full_path, basestring):
-        # if not isfile(full_path):
-        #     raise Http404('Static file not found')
-        with open(full_path) as file_contents:
-            file_data = file_contents.read()
+    with open(full_path) as file_contents:
+        file_data = file_contents.read()
 
-            # Normalise encoding
-            encoding = chardet.detect(file_data)['encoding']
-            file_data = file_data.decode(encoding).encode('utf-8')
+        # # Normalise encoding
+        encoding = chardet.detect(file_data)['encoding']
+        file_data = file_data.decode(encoding).encode('utf-8')
 
-            # 7 chars of sha1 hex
-            sha1_hash = sha1(file_data)
-            sha1_hex = sha1_hash.hexdigest()[:7]
+        # 7 chars of sha1 hex
+        sha1_hash = sha1(file_data)
+        sha1_hex = sha1_hash.hexdigest()[:7]
 
-            versioned_url_path += '?v=' + sha1_hex
+        versioned_url_path += '?v=' + sha1_hex
 
     return versioned_url_path
 

--- a/django_versioned_static_url/templatetags/versioned_static.py
+++ b/django_versioned_static_url/templatetags/versioned_static.py
@@ -1,6 +1,5 @@
 # System
 from hashlib import sha1
-from os.path import isfile
 
 # Modules
 import chardet
@@ -8,7 +7,6 @@ import logging
 from django import template
 from django.contrib.staticfiles.finders import find
 from django.templatetags.static import static
-from django.http import Http404
 
 
 logger = logging.getLogger(__name__)

--- a/django_versioned_static_url/templatetags/versioned_static.py
+++ b/django_versioned_static_url/templatetags/versioned_static.py
@@ -3,7 +3,6 @@ from hashlib import sha1
 from os.path import isfile
 
 # Modules
-import chardet
 from django import template
 from django.contrib.staticfiles.finders import find
 from django.templatetags.static import static
@@ -28,12 +27,11 @@ def versioned_static(file_path):
     url = static(file_path)
     versioned_url_path = url
 
-    with open(full_path) as file_contents:
+    with open(full_path, 'r') as file_contents:
         file_data = file_contents.read()
 
         # # Normalise encoding
-        encoding = chardet.detect(file_data)['encoding']
-        file_data = file_data.decode(encoding).encode('utf-8')
+        file_data = file_data.encode('utf-8')
 
         # 7 chars of sha1 hex
         sha1_hash = sha1(file_data)

--- a/django_versioned_static_url/templatetags/versioned_static.py
+++ b/django_versioned_static_url/templatetags/versioned_static.py
@@ -3,6 +3,7 @@ from hashlib import sha1
 from os.path import isfile
 
 # Modules
+import chardet
 from django import template
 from django.contrib.staticfiles.finders import find
 from django.templatetags.static import static
@@ -31,6 +32,11 @@ def versioned_static(file_path):
         file_data = file_contents.read()
 
         # # Normalise encoding
+        try:
+            encoding = chardet.detect(file_data)['encoding']
+            file_data = file_data.decode(encoding)
+        except ValueError:
+            pass
         file_data = file_data.encode('utf-8')
 
         # 7 chars of sha1 hex

--- a/django_versioned_static_url/templatetags/versioned_static.py
+++ b/django_versioned_static_url/templatetags/versioned_static.py
@@ -4,11 +4,14 @@ from os.path import isfile
 
 # Modules
 import chardet
+import logging
 from django import template
 from django.contrib.staticfiles.finders import find
 from django.templatetags.static import static
 from django.http import Http404
 
+
+logger = logging.getLogger(__name__)
 
 register = template.Library()
 
@@ -20,12 +23,13 @@ def versioned_static(file_path):
     """
 
     full_path = find(file_path)
+    url = static(file_path)
 
     if not full_path:
         msg = 'Could not find static file: {0}'.format(file_path)
-        raise Exception(msg)
+        logger.warning(msg)
+        return url
 
-    url = static(file_path)
     versioned_url_path = url
 
     with open(full_path, 'r') as file_contents:

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,6 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         "Django >= 1.3",
+        "chardet >= 2.3.0",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,5 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         "Django >= 1.3",
-        "chardet >= 2.3.0",
     ],
 )


### PR DESCRIPTION
- Update static file open and encoding

Open files as read only, and do not try to decode as the strings are
already decoded and Python 3 complains.
- Restructure error flow

Simplify the flow and print a clear error when the file does not exist.
As staticfile finder already checks if the file exists, and returns
None if not. Check against this result.
