### PR TITLE
Move to cChardet and open file in binary mode

### DIFF
--- a/django_versioned_static_url/templatetags/versioned_static.py
+++ b/django_versioned_static_url/templatetags/versioned_static.py
@@ -2,7 +2,7 @@
 from hashlib import sha1
 
 # Modules
-import chardet
+import cchardet
 import logging
 from django import template
 from django.contrib.staticfiles.finders import find
@@ -30,12 +30,12 @@ def versioned_static(file_path):
 
     versioned_url_path = url
 
-    with open(full_path, 'r') as file_contents:
+    with open(full_path, 'rb') as file_contents:
         file_data = file_contents.read()
 
         # # Normalise encoding
         try:
-            encoding = chardet.detect(file_data)['encoding']
+            encoding = cchardet.detect(file_data)['encoding']
             file_data = file_data.decode(encoding)
         except ValueError:
             pass

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
     long_description=open('README.rst').read(),
     install_requires=[
         "Django >= 1.3",
-        "chardet >= 2.3.0",
+        "cchardet >= 1.0.0",
     ],
 )


### PR DESCRIPTION
Chardet caused long slowdowns in some circumstances.
cChardet is built in c and considerably faster.

Opening the file in binary mode adds more compatibility
for python 2/3.
## QA

Run with with a large file (600+ KB) in both Python 2 and 3.
Page loads should be under 0.1 seconds, or no obvious slowdowns.

(This is measured with Apache Benchmark `ab`, on local dev of ubuntu.com).
